### PR TITLE
Set entryCost to zero on TechHidden parts

### DIFF
--- a/GameData/NearFutureLaunchVehicles/Legacy/Engine/engine-lfo-advanced/engine-lfo-advanced-125-2-deprecated.cfg
+++ b/GameData/NearFutureLaunchVehicles/Legacy/Engine/engine-lfo-advanced/engine-lfo-advanced-125-2-deprecated.cfg
@@ -26,7 +26,7 @@ PART
 	crashTolerance = 22
 	maxTemp = 2000 // = 3600
 	TechRequired = veryHeavyRocketry
-	entryCost = 86000
+	entryCost = 0
 	cost = 15000
   category = none
 	TechHidden = True

--- a/GameData/NearFutureLaunchVehicles/Legacy/Engine/engine-lfo-advanced/engine-lfo-advanced-25-1-deprecated.cfg
+++ b/GameData/NearFutureLaunchVehicles/Legacy/Engine/engine-lfo-advanced/engine-lfo-advanced-25-1-deprecated.cfg
@@ -26,7 +26,7 @@ PART
 	crashTolerance = 22
 	maxTemp = 2000 // = 3600
 	TechRequired = veryHeavyRocketry
-	entryCost = 124000
+	entryCost = 0
 	cost = 43200
   category = none
 	TechHidden = True

--- a/GameData/NearFutureLaunchVehicles/Legacy/LegacyPartHider.cfg
+++ b/GameData/NearFutureLaunchVehicles/Legacy/LegacyPartHider.cfg
@@ -2,6 +2,7 @@
 @PART[*]:HAS[@MODEL:HAS[#model[NearFutureLaunchVehicles/Legacy*]]]
 {
    %TechHidden = True
+  @entryCost = 0
   @category = none
   @subcategory = 0
 

--- a/GameData/NearFutureLaunchVehicles/Patches/NFLaunchVehiclesOverlappingParts.cfg
+++ b/GameData/NearFutureLaunchVehicles/Patches/NFLaunchVehiclesOverlappingParts.cfg
@@ -7,6 +7,7 @@
 @PART[Size4_Tank_04|Size4_Tank_03|Size4_Tank_02|Size4_Tank_01|Size3_Size4_Adapter_01|Decoupler_4|Separator_4|fairingSize4]:NEEDS[SquadExpansion/MakingHistory]
 {
   %TechHidden = True
+  @entryCost = 0
   @category = none
   @subcategory = 0
 
@@ -16,6 +17,7 @@
 @PART[restock-fueltank-5-1|restock-fueltank-5-2|restock-fueltank-5-3|restock-fueltank-5-4|restock-fueltank-adapter-375-5-1|restock-decoupler-5-1|restock-separator-5-1|restock-fairing-base-5-1]:NEEDS[ReStockPlus]:AFTER[ReStockPlus]
 {
   %TechHidden = True
+  @entryCost = 0
   @category = none
   @subcategory = 0
 


### PR DESCRIPTION
A TechHidden part's entryCost isn't included in the price shown on the tech node's "purchase all parts" button, but clicking the button actually charges the player for hidden parts nonetheless.  This is a bug in the game, but it has a simple workaround: set entryCost to zero on parts that have the TechHidden flag.  (Squad's deprecated parts do this too.)

See also: PorktoberRevolution/ReStocked#920